### PR TITLE
Set default DPI

### DIFF
--- a/R/Cairo.R
+++ b/R/Cairo.R
@@ -21,7 +21,7 @@ Cairo <- function(width=640, height=480, file="", type="png", pointsize=12, bg="
 		stop("connection must be open and writeable")
 	if (length(units)!=1 || ! units %in% c("px","pt","in","cm","mm"))
 		stop("invalid unit (supported are px, pt, in, cm and mm)")
-	if (any(dpi=="auto" || dpi=="")) dpi <- 0
+	if (any(dpi=="auto" || dpi=="")) dpi <- 72
 	if (length(dpi)!=1 || !is.numeric(dpi) || dpi<0)
 		stop("invalid dpi specification (must be 'auto' or a positive number)")
 	dpi <- as.double(dpi)


### PR DESCRIPTION
Hi,

With version 1.5-3, you are now using the dpi variable in Rcairo_new_device_driver (cairogd.c) to calculate the nominal character sizes in pixels.

First you calculate a scaling ratio by dividing the desired DPI by 72.

```
dpi_exX = dpi[0] / 72.0;
dpi_exY = dpi[1] / 72.0;
```

Then use the result in determining the nominal character sizes:

```
dd->cra[0] = 0.9 * initps * dpi_exX; /* FIXME: we should use font metric for this */
dd->cra[1] = 1.2 * initps * dpi_exY;
xd->basefontsize *= dpi_exX;
```

However, in case the dpi argument in the Cairo() R call is missing ("auto") or empty, you set it to 0:

```
if (any(dpi=="auto" || dpi=="")) dpi <- 0
```

This results in dpi_exX = 0 and dpi_exY = 0, and then 0 sizes for the characters, due to the multiplication.

At the end this causes the following example:

```
library(Cairo)
Cairo(450, 450, type = 'raster', bg = "#FFFFFF")

library(lattice)
x <- seq(pi/4, 5 * pi, length.out = 100)
y <- seq(pi/4, 5 * pi, length.out = 100)
r <- as.vector(sqrt(outer(x^2, y^2, "+")))
grid <- expand.grid(x=x, y=y)
grid$z <- cos(r^2) * exp(-r/(pi^3))
print(levelplot(z~x*y, grid, cuts = 50, scales=list(log="e"), xlab="",
          ylab="", main="Weird Function", sub="with log scales",
          colorkey = FALSE, region = TRUE))
```

to fail with:

```
Error in grid.Call(L_textBounds, as.graphicsAnnot(x$label), x$x, x$y,  : 
  polygon edge not found
```

The workaround is to declare dpi in the Cairo() R call. I think the solution should be to set the default dpi to 72, therefore having no scaling (dpi_exX = 1 and dpi_exY = 1).
