### PR TITLE
xd->npages is set incorrect on cairotalk.c

### DIFF
--- a/src/cairotalk.c
+++ b/src/cairotalk.c
@@ -413,7 +413,7 @@ static void CairoGD_Close(NewDevDesc *dd)
   xd->cb->save_page(xd->cb,xd->npages);
   if (xd->cb->onSave && xd->cb->onSave != R_NilValue) {
 	  SEXP devNr = PROTECT(ScalarInteger(ndevNumber(dd) + 1));
-	  SEXP pageNr = PROTECT(ScalarInteger(xd->npages + 1));
+	  SEXP pageNr = PROTECT(ScalarInteger(xd->npages));
 	  eval(lang3(xd->cb->onSave, devNr, pageNr), R_GlobalEnv);
 	  UNPROTECT(2);
 	  R_ReleaseObject(xd->cb->onSave);


### PR DESCRIPTION
In function CairoGD_Close, xd->npages is increased by 1 on Line 412 xd->npages++;
using xd->npages + 1 on Line 415 is incorrect.

R> img.png <- list()
R> dev <- Cairo(800, 600, type='raster', bg="white")
R> Cairo.onSave(dev, function(dev, page) {
       .GlobalEnv$img.png[[page]] <- writePNG(Cairo.capture(dev)) })
NULL

R> plot(1:10, col=2)
R> plot(1:15)
format = RGB (800 x 600)
Error in .GlobalEnv$img.png[[page]] <- writePNG(Cairo.capture(dev)) : 
  more elements supplied than there are to replace
