### PR TITLE
connection support via R_ext/Connection.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,17 @@ fi
 
 AC_MSG_NOTICE([CAIRO_CFLAGS=${CAIRO_CFLAGS}])
 
+# Check for New Connections support
+AC_MSG_CHECKING([if R have R_ext/Connections.h])
+if test -f "${R_HOME}/include/R_ext/Connections.h"; then
+	AC_MSG_RESULT([yes])
+	HAVE_RCONN_H="-DHAVE_NEW_CONN_H"
+else
+	AC_MSG_RESULT([no])
+	HAVE_RCONN_H=""
+fi
+
+
 # Check for Rconn patch
 AC_MSG_CHECKING([if R was compiled with the RConn patch])
 if test -f "${R_HOME}/include/R_ext/RConn.h"; then
@@ -89,7 +100,7 @@ else
 	HAVE_RCONN_H=""
 fi
 
-CPPFLAGS="$CPPFLAGS ${CAIRO_CFLAGS} ${HAVE_RCONN_H}"
+CPPFLAGS="$CPPFLAGS ${CAIRO_CFLAGS} ${HAVE_NEW_CONN_H} ${HAVE_RCONN_H}"
 
 AC_CHECK_HEADER(cairo.h,,AC_MSG_ERROR([Cannot find cairo.h! Please install cairo (http://www.cairographics.org/) and/or set CAIRO_CFLAGS/LIBS correspondingly.]))
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -11,6 +11,24 @@
 #include <R_ext/GraphicsEngine.h>
 #include <R_ext/GraphicsDevice.h>
 
+#if defined(HAVE_NEW_CONN_H) || defined(HAVE_RCONN_H)
+#include <R.h>
+#include <Rinternals.h>
+#include <Rdefines.h>
+#define R_INTERFACE_PTRS
+#include <Rinterface.h>
+#include <Rembedded.h>
+#include <R_ext/Print.h>
+#ifdef HAVE_NEW_CONN_H
+#include <R_ext/Connections.h>
+#endif
+#ifdef HAVE_RCONN_H
+#include <R_ext/RConn.h>
+#endif
+#endif
+
+
+
 #if R_VERSION >= R_Version(2,8,0)
 #ifndef NewDevDesc
 #define NewDevDesc DevDesc

--- a/src/cairogd.c
+++ b/src/cairogd.c
@@ -47,7 +47,10 @@ static SEXP findArg(char *name, SEXP list) {
    -
    gamma: 0.6
 */
-Rboolean Rcairo_new_device_driver(NewDevDesc *dd, const char *type, int conn, const char *file,
+#if defined(HAVE_RCONN_H)
+#define Rconnection int
+#endif
+Rboolean Rcairo_new_device_driver(NewDevDesc *dd, const char *type, Rconnection conn, const char *file,
 								  double width, double height, double initps,
 								  int bgcolor, int canvas, double umul, double *dpi, SEXP aux)
 {
@@ -196,7 +199,11 @@ SEXP cairo_create_new_device(SEXP args)
 	const char *type, *file = NULL;
 	double width, height, initps, umul, dpi[2];
 	int bgcolor = -1, canvas = -1;
+#if  defined(HAVE_RCONN_H)
 	int conn = -1;
+#elif defined(HAVE_NEW_CONN_H) 
+        Rconnection conn = NULL;
+#endif
 
 	SEXP v;
 	args=CDR(args);
@@ -211,9 +218,12 @@ SEXP cairo_create_new_device(SEXP args)
 		PROTECT(v);
 		file=CHAR(STRING_ELT(v,0));
 		UNPROTECT(1);
+#if  defined(HAVE_RCONN_H)
 	} else if (isInteger(v)){
-#ifdef HAVE_RCONN_H
 		conn = asInteger(v);
+#elif defined(HAVE_NEW_CONN_H) 
+        } else if (1){
+                conn = R_GetConnection(v);
 #else
 		error("file must be a filename. to support writing to a connection, recompile R and Cairo with the R Connection Patch. ");
 #endif

--- a/src/cairotalk.c
+++ b/src/cairotalk.c
@@ -595,7 +595,7 @@ static SEXP findArg(const char *name, SEXP list) {
 	return 0;
 }
 
-Rboolean CairoGD_Open(NewDevDesc *dd, CairoGDDesc *xd,  const char *type, int conn, const char *file, double w, double h,
+Rboolean CairoGD_Open(NewDevDesc *dd, CairoGDDesc *xd,  const char *type, Rconnection conn, const char *file, double w, double h,
 					  double umpl, SEXP aux)
 {
 	if (umpl==0) error("unit multiplier cannot be zero");

--- a/src/cairotalk.h
+++ b/src/cairotalk.h
@@ -8,7 +8,7 @@
 #include "cairo.h"
 
 void Rcairo_setup_gd_functions(NewDevDesc *dd);
-Rboolean CairoGD_Open(NewDevDesc *dd, CairoGDDesc *xd, const char *type, int conn, const char *file,
+Rboolean CairoGD_Open(NewDevDesc *dd, CairoGDDesc *xd, const char *type, Rconnection conn, const char *file,
 		      double w, double h, double umpl, SEXP aux);
 
 #ifdef CAIRO_HAS_FT_FONT

--- a/src/img-backend.h
+++ b/src/img-backend.h
@@ -9,7 +9,7 @@
 typedef struct st_Rcairo_image_backend {
   void *buf;
   char *filename;
-  int  conn;
+  Rconnection  conn;
   int  quality;
   cairo_format_t format;
   SEXP locator_call, locator_dev;
@@ -18,7 +18,7 @@ typedef struct st_Rcairo_image_backend {
 
 extern Rcairo_backend_def *RcairoBackendDef_image;
 
-Rcairo_backend *Rcairo_new_image_backend(Rcairo_backend *be, int conn, const char *filename, const char *type,
+Rcairo_backend *Rcairo_new_image_backend(Rcairo_backend *be, Rconnection conn, const char *filename, const char *type,
 					 int width, int height, int quality, int alpha_plane, SEXP locator_cb);
 
 #endif

--- a/src/pdf-backend.h
+++ b/src/pdf-backend.h
@@ -9,6 +9,6 @@ extern Rcairo_backend_def *RcairoBackendDef_pdf;
 #include <cairo-pdf.h>
 #endif
 
-Rcairo_backend *Rcairo_new_pdf_backend(Rcairo_backend *be, int conn, const char *filename, double width, double height);
+Rcairo_backend *Rcairo_new_pdf_backend(Rcairo_backend *be, Rconnection conn, const char *filename, double width, double height);
 
 #endif

--- a/src/ps-backend.c
+++ b/src/ps-backend.c
@@ -1,7 +1,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include "ps-backend.h"
-#ifdef HAVE_RCONN_H
+
+#if defined(HAVE_NEW_CONN_H) || defined(HAVE_RCONN_H)
 #include <R.h>
 #include <Rinternals.h>
 #include <Rdefines.h>
@@ -9,7 +10,12 @@
 #include <Rinterface.h>
 #include <Rembedded.h>
 #include <R_ext/Print.h>
+#ifdef HAVE_NEW_CONN_H
+#include <R_ext/Connections.h>
+#endif
+#ifdef HAVE_RCONN_H
 #include <R_ext/RConn.h>
+#endif
 #endif
 
 #if CAIRO_HAS_PDF_SURFACE
@@ -28,14 +34,18 @@ static void ps_save_page(Rcairo_backend* be, int pageno){
 	cairo_show_page(be->cc);
 }
 
-#ifdef HAVE_RCONN_H
+#if defined(HAVE_NEW_CONN_H) || defined(HAVE_RCONN_H)
 static cairo_status_t send_image_data(void *closure, const unsigned char *data, unsigned int length)
 {
 	Rcairo_backend *be = (Rcairo_backend *)closure;
-	int conn;
-	conn = *(int *)be->backendSpecific;
+	Rconnection conn;
+	conn = *(Rconnection *)be->backendSpecific;
 
+#if defined(HAVE_NEW_CONN_H)
+	if (R_WriteConnection(conn, (void*)data, length))
+#else
 	if (R_WriteConnection(conn, data, length, 1))
+#endif
 		return CAIRO_STATUS_SUCCESS;
 	else
 		return CAIRO_STATUS_WRITE_ERROR;
@@ -49,7 +59,7 @@ static void ps_backend_destroy(Rcairo_backend* be)
 	free(be);
 }
 
-Rcairo_backend *Rcairo_new_ps_backend(Rcairo_backend *be, int conn, const char *filename, double width, double height)
+Rcairo_backend *Rcairo_new_ps_backend(Rcairo_backend *be, Rconnection conn, const char *filename, double width, double height)
 {
 	be->backend_type = BET_PS;
 	be->destroy_backend = ps_backend_destroy;
@@ -69,11 +79,11 @@ Rcairo_backend *Rcairo_new_ps_backend(Rcairo_backend *be, int conn, const char *
 		be->cs = cairo_ps_surface_create(filename,(double)width,(double)height);
 		if (fn) free(fn);
 	} else {
-#ifdef HAVE_RCONN_H
+#if defined(HAVE_NEW_CONN_H) || defined(HAVE_RCONN_H)
 		if ( ! (be->backendSpecific =  calloc(1,sizeof(int)))){
 			free(be); return NULL;
 		}
-		*(int *)be->backendSpecific = conn;
+		*(Rconnection *)be->backendSpecific = conn;
 		be->cs = cairo_ps_surface_create_for_stream(send_image_data,(void *)be,(double)width,(double)height);
 #else
 		free(be); return NULL;

--- a/src/ps-backend.h
+++ b/src/ps-backend.h
@@ -9,6 +9,6 @@
 
 extern Rcairo_backend_def *RcairoBackendDef_ps;
 
-Rcairo_backend *Rcairo_new_ps_backend(Rcairo_backend *be, int conn, const char *filename, double width, double height);
+Rcairo_backend *Rcairo_new_ps_backend(Rcairo_backend *be, Rconnection conn, const char *filename, double width, double height);
 
 #endif

--- a/src/svg-backend.c
+++ b/src/svg-backend.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "svg-backend.h"
-#ifdef HAVE_RCONN_H
+#if defined(HAVE_NEW_CONN_H) || defined(HAVE_RCONN_H)
 #include <R.h>
 #include <Rinternals.h>
 #include <Rdefines.h>
@@ -9,7 +9,12 @@
 #include <Rinterface.h>
 #include <Rembedded.h>
 #include <R_ext/Print.h>
+#ifdef HAVE_NEW_CONN_H
+#include <R_ext/Connections.h>
+#endif
+#ifdef HAVE_RCONN_H
 #include <R_ext/RConn.h>
+#endif
 #endif
 
 #if CAIRO_HAS_SVG_SURFACE
@@ -28,14 +33,18 @@ static void svg_save_page(Rcairo_backend* be, int pageno){
 	cairo_show_page(be->cc);
 }
 
-#ifdef HAVE_RCONN_H
+#if defined(HAVE_NEW_CONN_H) || defined(HAVE_RCONN_H)
 static cairo_status_t send_image_data(void *closure, const unsigned char *data, unsigned int length)
 {
 	Rcairo_backend *be = (Rcairo_backend *)closure;
-	int conn;
-	conn = *(int *)be->backendSpecific;
+	Rconnection conn;
+	conn = *(Rconnection *)be->backendSpecific;
 
+#if defined(HAVE_NEW_CONN_H)
+	if (R_WriteConnection(conn, (void *)data, length))
+#else
 	if (R_WriteConnection(conn, data, length, 1))
+#endif
 		return CAIRO_STATUS_SUCCESS;
 	else
 		return CAIRO_STATUS_WRITE_ERROR;
@@ -49,7 +58,7 @@ static void svg_backend_destroy(Rcairo_backend* be)
 	free(be);
 }
 
-Rcairo_backend *Rcairo_new_svg_backend(Rcairo_backend *be, int conn, const char *filename, double width, double height)
+Rcairo_backend *Rcairo_new_svg_backend(Rcairo_backend *be, Rconnection conn, const char *filename, double width, double height)
 {
 	be->backend_type = BET_SVG;
 	be->destroy_backend = svg_backend_destroy;
@@ -69,11 +78,11 @@ Rcairo_backend *Rcairo_new_svg_backend(Rcairo_backend *be, int conn, const char 
 		be->cs = cairo_svg_surface_create(filename,(double)width,(double)height);
 		if (fn) free(fn);
 	} else {
-#ifdef HAVE_RCONN_H
+#if defined(HAVE_NEW_CONN_H) || defined(HAVE_RCONN_H)
 		if ( ! (be->backendSpecific =  calloc(1,sizeof(int)))){
 			free(be); return NULL;
 		}
-		*(int *)be->backendSpecific = conn;
+		*(Rconnection *)be->backendSpecific = conn;
 		be->cs = cairo_svg_surface_create_for_stream(send_image_data,(void *)be,(double)width,(double)height);
 #else
 		free(be); return NULL;

--- a/src/svg-backend.h
+++ b/src/svg-backend.h
@@ -9,6 +9,6 @@
 
 extern Rcairo_backend_def *RcairoBackendDef_svg;
 
-Rcairo_backend *Rcairo_new_svg_backend(Rcairo_backend *be, int conn, const char *filename, double width, double height);
+Rcairo_backend *Rcairo_new_svg_backend(Rcairo_backend *be, Rconnection conn, const char *filename, double width, double height);
 
 #endif


### PR DESCRIPTION
In recent version of R (3.3.1), there is R_ext/Connection.h but no R_ext/RConn.h.
This is somewhat from the situation for "RConn patch", but connection is integrated into the main R source.  It should be worthwhile to make them work with Cairo again. 
By just matching the types, the code seems to work, though I have not tested very thoroughly yet and there seems to room for cleaner codes. Nonetheless, I would show you this code as this could be some starting point to support again.