### PR TITLE
BUG fix: Cairo cannot find freetype.h because of a missing $ sign.

### DIFF
--- a/configure
+++ b/configure
@@ -4001,7 +4001,7 @@ printf %s "checking whether fontconfig/freetype2 location can be guessed... " >&
         FCI="-I${pre}/include"
 	FCL="-L${pre}/lib"
      fi
-     if test -z "{FTI}" -a -e "${pre}/include/freetype2/freetype/freetype.h"; then
+     if test -z "${FTI}" -a -e "${pre}/include/freetype2/freetype/freetype.h"; then
         FTI="-I${pre}/include/freetype2"
 	FTL="-L${pre}/lib"
      fi

--- a/configure.ac
+++ b/configure.ac
@@ -206,7 +206,7 @@ if test "${need_xtra_ft_flags}" = yes; then
         FCI="-I${pre}/include"
 	FCL="-L${pre}/lib"
      fi
-     if test -z "{FTI}" -a -e "${pre}/include/freetype2/freetype/freetype.h"; then
+     if test -z "${FTI}" -a -e "${pre}/include/freetype2/freetype/freetype.h"; then
         FTI="-I${pre}/include/freetype2"
 	FTL="-L${pre}/lib"
      fi


### PR DESCRIPTION
Fix an error that prevents `Cairo` installation. Cairo cannot find `freetype.h`, even though it is present in the system.