### PR TITLE
Add support for bi-directional text, ligatures etc. via Harfbuzz

### DIFF
--- a/configure
+++ b/configure
@@ -701,6 +701,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+with_harfbuzz
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1323,6 +1324,13 @@ if test -n "$ac_init_help"; then
      short | recursive ) echo "Configuration of Cairo 1.3:";;
    esac
   cat <<\_ACEOF
+
+Optional Packages:
+  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-harfbuzz         compile support for bi-directional Unicode and
+                          advanced text layout (like ligature support) using
+                          Harfbuzz and ICU libraries. (default is [auto]).
 
 Some influential environment variables:
   CC          C compiler command
@@ -4088,6 +4096,23 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 
 # --- check for Harfbuzz/ICU support ---
+
+
+# Check whether --with-harfbuzz was given.
+if test ${with_harfbuzz+y}
+then :
+  withval=$with_harfbuzz; with_harfbuzz=$withval
+else $as_nop
+  with_harfbuzz=auto
+fi
+
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether Harfbuzz layout is desired" >&5
+printf %s "checking whether Harfbuzz layout is desired... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${with_harfbuzz}" >&5
+printf "%s\n" "${with_harfbuzz}" >&6; }
+
+if test x${with_harfbuzz} != xno; then
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether Harfbuzz + ICU works" >&5
 printf %s "checking whether Harfbuzz + ICU works... " >&6; }
 zLIBS="${LIBS}"
@@ -4101,6 +4126,7 @@ if test -z "${HB_LIBS}"; then
 fi
 LIBS="${LIBS} ${HB_LIBS} -lstdc++"
 CPPFLAGS="${CPPFLAGS} ${HB_CPPFLAGS}"
+
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -4137,6 +4163,7 @@ printf "%s\n" "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
+fi
 
 # --- check for TIFF support
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether libtiff works" >&5

--- a/configure
+++ b/configure
@@ -701,6 +701,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+with_freetype
 with_harfbuzz
 '
       ac_precious_vars='build_alias
@@ -1328,6 +1329,9 @@ if test -n "$ac_init_help"; then
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-freetype         compile support for better font handling using
+                          FreeType and Fontconfig if present and supported by
+                          cairo. (default is [auto]).
   --with-harfbuzz         compile support for bi-directional Unicode and
                           advanced text layout (like ligature support) using
                           Harfbuzz and ICU libraries. (default is [auto]).
@@ -3936,6 +3940,23 @@ fi
 
 
 has_cairo_ft=no
+
+
+# Check whether --with-freetype was given.
+if test ${with_freetype+y}
+then :
+  withval=$with_freetype; with_freetype=$withval
+else $as_nop
+  with_freetype=auto
+fi
+
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether FreeType support is desired" >&5
+printf %s "checking whether FreeType support is desired... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${with_freetype}" >&5
+printf "%s\n" "${with_freetype}" >&6; }
+
+if test x${with_freetype} != xno; then ## with_freetype
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for FreeType support in cairo" >&5
 printf %s "checking for FreeType support in cairo... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -4062,6 +4083,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 fi
+fi ## with_freetype
 
 # --- check for JPEG support ---
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether libjpeg works" >&5
@@ -4111,7 +4133,18 @@ fi
 printf %s "checking whether Harfbuzz layout is desired... " >&6; }
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${with_harfbuzz}" >&5
 printf "%s\n" "${with_harfbuzz}" >&6; }
-
+if test x${with_harfbuzz} != xno; then
+if test x${has_cairo_ft} != xyes; then
+  if test x${with_harfbuzz} = xyes; then
+    as_fn_error $? "ERROR: Harfbuzz support is requested, but FreeType is not available.
+    Harfbuzz requires cairo with FreeType support to be present." "$LINENO" 5
+  else
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: NOTE: Harfbuzz requires cairo with FreeType support which is not available." >&5
+printf "%s\n" "$as_me: NOTE: Harfbuzz requires cairo with FreeType support which is not available." >&6;}
+  fi
+  with_harfbuzz=no
+fi
+fi
 if test x${with_harfbuzz} != xno; then
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether Harfbuzz + ICU works" >&5
 printf %s "checking whether Harfbuzz + ICU works... " >&6; }

--- a/configure
+++ b/configure
@@ -4056,8 +4056,8 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 fi
 
 # --- check for JPEG support ---
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking wheter libjpeg works" >&5
-printf %s "checking wheter libjpeg works... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether libjpeg works" >&5
+printf %s "checking whether libjpeg works... " >&6; }
 zLIBS="${LIBS}"
 LIBS="${LIBS} -ljpeg"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -4087,9 +4087,60 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 
+# --- check for Harfbuzz/ICU support ---
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether Harfbuzz + ICU works" >&5
+printf %s "checking whether Harfbuzz + ICU works... " >&6; }
+zLIBS="${LIBS}"
+zCPPFLAGS="${CPPFLAGS}"
+if test -n "$PKGCONF"; then
+: ${HB_CPPFLAGS=`"${PKGCONF}" --cflags harfbuzz-icu`}
+: ${HB_LIBS=`"${PKGCONF}" --libs ${PKGCONF_LIB_ADD} harfbuzz-icu`}
+fi
+if test -z "${HB_LIBS}"; then
+  HB_LIBS='-lharfbuzz-icu -licuuc -licudata -lharfbuzz'
+fi
+LIBS="${LIBS} ${HB_LIBS} -lstdc++"
+CPPFLAGS="${CPPFLAGS} ${HB_CPPFLAGS}"
+
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <unicode/ubidi.h>
+#include <unicode/uchar.h>
+
+#include <harfbuzz/hb.h>
+#include <harfbuzz/hb-ft.h>
+#include <harfbuzz/hb-icu.h>
+int main(void) {
+  UBiDi *bidi = 0;
+  UChar *text = 0;
+  bidi = ubidi_open();
+  hb_buffer_t *buf = hb_buffer_create();
+  hb_buffer_set_unicode_funcs(buf, hb_icu_get_unicode_funcs());
+  return 0;
+}
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+printf "%s\n" "#define HAVE_HARFBUZZ 1" >>confdefs.h
+
+else $as_nop
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+    LIBS="${zLIBS}"
+    CPPFLAGS="${zCPPFLAGS}"
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
 # --- check for TIFF support
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking wheter libtiff works" >&5
-printf %s "checking wheter libtiff works... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether libtiff works" >&5
+printf %s "checking whether libtiff works... " >&6; }
 zLIBS="${LIBS}"
 if test -n "$PKGCONF"; then
   ## FIXME: --cflags?

--- a/configure.ac
+++ b/configure.ac
@@ -262,6 +262,15 @@ int main(void) {
     LIBS="${zLIBS}"])
 
 # --- check for Harfbuzz/ICU support ---
+
+AC_ARG_WITH([harfbuzz],
+  AS_HELP_STRING(--with-harfbuzz,[compile support for bi-directional Unicode and advanced text layout (like ligature support) using Harfbuzz and ICU libraries. (default is @<:@auto@:>@).]),
+        [with_harfbuzz=$withval], [with_harfbuzz=auto])
+
+AC_MSG_CHECKING([whether Harfbuzz layout is desired])
+AC_MSG_RESULT(${with_harfbuzz})
+
+if test x${with_harfbuzz} != xno; then
 AC_MSG_CHECKING([whether Harfbuzz + ICU works])
 zLIBS="${LIBS}"
 zCPPFLAGS="${CPPFLAGS}"
@@ -274,6 +283,7 @@ if test -z "${HB_LIBS}"; then
 fi
 LIBS="${LIBS} ${HB_LIBS} -lstdc++"
 CPPFLAGS="${CPPFLAGS} ${HB_CPPFLAGS}"
+
 
 AC_LINK_IFELSE([AC_LANG_SOURCE([
 #include <unicode/ubidi.h>
@@ -296,6 +306,7 @@ int main(void) {
     LIBS="${zLIBS}"
     CPPFLAGS="${zCPPFLAGS}"
     ])
+fi
 
 # --- check for TIFF support
 AC_MSG_CHECKING([whether libtiff works])

--- a/configure.ac
+++ b/configure.ac
@@ -261,6 +261,42 @@ int main(void) {
   [ AC_MSG_RESULT(no)
     LIBS="${zLIBS}"])
 
+# --- check for Harfbuzz/ICU support ---
+AC_MSG_CHECKING([whether Harfbuzz + ICU works])
+zLIBS="${LIBS}"
+zCPPFLAGS="${CPPFLAGS}"
+if test -n "$PKGCONF"; then
+: ${HB_CPPFLAGS=`"${PKGCONF}" --cflags harfbuzz-icu`}
+: ${HB_LIBS=`"${PKGCONF}" --libs ${PKGCONF_LIB_ADD} harfbuzz-icu`}
+fi
+if test -z "${HB_LIBS}"; then
+  HB_LIBS='-lharfbuzz-icu -licuuc -licudata -lharfbuzz'
+fi
+LIBS="${LIBS} ${HB_LIBS} -lstdc++"
+CPPFLAGS="${CPPFLAGS} ${HB_CPPFLAGS}"
+
+AC_LINK_IFELSE([AC_LANG_SOURCE([
+#include <unicode/ubidi.h>
+#include <unicode/uchar.h>
+
+#include <harfbuzz/hb.h>
+#include <harfbuzz/hb-ft.h>
+#include <harfbuzz/hb-icu.h>
+int main(void) {
+  UBiDi *bidi = 0;
+  UChar *text = 0;
+  bidi = ubidi_open();
+  hb_buffer_t *buf = hb_buffer_create();
+  hb_buffer_set_unicode_funcs(buf, hb_icu_get_unicode_funcs());
+  return 0;
+}
+])],[ AC_MSG_RESULT([yes])
+    AC_DEFINE(HAVE_HARFBUZZ, 1, [Define to 1 if Harfbuzz and ICU are present and working])],
+  [ AC_MSG_RESULT(no)
+    LIBS="${zLIBS}"
+    CPPFLAGS="${zCPPFLAGS}"
+    ])
+
 # --- check for TIFF support
 AC_MSG_CHECKING([whether libtiff works])
 zLIBS="${LIBS}"

--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,15 @@ dnl fi
 AC_CHECK_DECLS([cairo_image_surface_get_format], [#include <cairo.h>])
 
 has_cairo_ft=no
+
+AC_ARG_WITH([freetype],
+  AS_HELP_STRING(--with-freetype,[compile support for better font handling using FreeType and Fontconfig if present and supported by cairo. (default is @<:@auto@:>@).]),
+        [with_freetype=$withval], [with_freetype=auto])
+
+AC_MSG_CHECKING([whether FreeType support is desired])
+AC_MSG_RESULT(${with_freetype})
+
+if test x${with_freetype} != xno; then ## with_freetype
 AC_MSG_CHECKING([for FreeType support in cairo])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #include <cairo.h>
@@ -243,6 +252,7 @@ int main(void) {
  AC_MSG_ERROR([Cannot use cairo-ft backend, although cairo claims it is working. Please check your caito installation and/or update cairo if necessary or set CAIRO_CFLAGS/CAIRO_LIBS accordingly.])
  ])
 fi
+fi ## with_freetype
 
 # --- check for JPEG support ---
 AC_MSG_CHECKING([whether libjpeg works])
@@ -269,7 +279,17 @@ AC_ARG_WITH([harfbuzz],
 
 AC_MSG_CHECKING([whether Harfbuzz layout is desired])
 AC_MSG_RESULT(${with_harfbuzz})
-
+if test x${with_harfbuzz} != xno; then
+if test x${has_cairo_ft} != xyes; then
+  if test x${with_harfbuzz} = xyes; then
+    AC_MSG_ERROR([ERROR: Harfbuzz support is requested, but FreeType is not available.
+    Harfbuzz requires cairo with FreeType support to be present.])
+  else
+    AC_MSG_NOTICE([NOTE: Harfbuzz requires cairo with FreeType support which is not available.])
+  fi
+  with_harfbuzz=no
+fi
+fi
 if test x${with_harfbuzz} != xno; then
 AC_MSG_CHECKING([whether Harfbuzz + ICU works])
 zLIBS="${LIBS}"

--- a/src/cairotalk.c
+++ b/src/cairotalk.c
@@ -748,7 +748,6 @@ static void chb_add_glyphs(rc_text_shape *rc, Rcairo_font_face *fcface,
 /* split text into runs with the same directionality then call HB to shape each run.
    The result is a set of cairo glyphs with locations */
 static rc_text_shape *c_setup_glyphs(CairoGDDesc *xd, R_GE_gcontext *gc, const char *str) {
-	cairo_t *cc = xd->cb->cc;
 	UBiDi *bidi = 0;
 	UChar *text = 0;
 	UErrorCode err = U_ZERO_ERROR;
@@ -1291,18 +1290,6 @@ static double CairoGD_StrWidth(constxt char *str,  R_GE_gcontext *gc,  NewDevDes
 		return te.x_advance;
 	}
 }
-
-#ifdef HAVE_HARFBUZZ
-static void rc_glyphs_move(rc_text_shape *ts, double x, double y) {
-	unsigned int i = 0;
-	while (i < ts->glyphs) {
-		ts->glyph[i].x += x;
-		ts->glyph[i++].y += y;
-	}
-	ts->x += x;
-	ts->y += y;
-}
-#endif
 
 static void CairoGD_Text(double x, double y, constxt char *str,  double rot, double hadj,  R_GE_gcontext *gc,  NewDevDesc *dd)
 {

--- a/src/cconfig.h.in
+++ b/src/cconfig.h.in
@@ -4,6 +4,9 @@
    `cairo_image_surface_get_format', and to 0 if you don't. */
 #undef HAVE_DECL_CAIRO_IMAGE_SURFACE_GET_FORMAT
 
+/* Define to 1 if Harfbuzz and ICU are present and working */
+#undef HAVE_HARFBUZZ
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 


### PR DESCRIPTION
Uses Harfbuzz and ICU to detect changing scripts and text directions and render each part in the appropriate direction. This also supports ligatures and more complex script shaping. In additon, it enables support for both native and UTF-8 encoded drawing.

This branch also supports custom font family handling in both FreeType and Harfbuzz code paths.