### PR TITLE
Update linking on Windows to support latest Rtools43

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -9,4 +9,5 @@ BITS=32
 endif
 
 PKG_CPPFLAGS=-I. -I$(LOCAL_SOFT)/include/cairo -I$(LOCAL_SOFT)/include/freetype2 $(XTRA_PKG_CPPFLAGS)
-PKG_LIBS=-lcairo -lfontconfig -lintl -liconv -lexpat -lfreetype -lharfbuzz -lpixman-1 -ltiff -lwebp -llzma -lzstd -ljpeg -lpng -lbz2 -lz -lgdi32 -lmsimg32 $(GRAPHAPP_LIB)
+LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+PKG_LIBS=-lcairo -lfontconfig -lintl -liconv -lexpat -lfreetype -lharfbuzz -lpixman-1 -ltiff -lwebp $(LIBSHARPYUV) -llzma -lzstd -ljpeg -lpng -lbz2 -lz -lgdi32 -lmsimg32 $(GRAPHAPP_LIB)


### PR DESCRIPTION
This change to linking is to support current version of Rtools43, where webp ships with separate sharpyuv. The earlier version of webp included sharpyuv, hence the conditioning.