### PR TITLE
Use pkg-config on Windows when available.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -8,5 +8,18 @@ else
 BITS=32
 endif
 
-PKG_CPPFLAGS=-I. -I$(LOCAL_SOFT)/include/cairo -I$(LOCAL_SOFT)/include/freetype2 $(XTRA_PKG_CPPFLAGS)
-PKG_LIBS=-lcairo -lfontconfig -lintl -liconv -lexpat -lfreetype -lharfbuzz -lpixman-1 -ltiff -lwebp -llzma -lzstd -ljpeg -lpng -lbz2 -lz -lgdi32 -lmsimg32 $(GRAPHAPP_LIB)
+PKG_CPPFLAGS = -I.
+
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  PKG_CPPFLAGS += -I$(LOCAL_SOFT)/include/cairo -I$(LOCAL_SOFT)/include/freetype2
+  LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+  PKG_LIBS += -lcairo -lfontconfig -lintl -liconv -lexpat -lfreetype -lharfbuzz \
+              -lpixman-1 -ltiff -lwebp $(LIBSHARPYUV) -llzma -lzstd -ljpeg -lpng -lbz2 \
+              -lz -lgdi32 -lmsimg32
+else
+  PKG_CPPFLAGS += $(shell pkg-config --cflags cairo libtiff-4 libjpeg)
+  PKG_LIBS += $(shell pkg-config --libs cairo libtiff-4 libjpeg)
+endif
+
+PKG_LIBS += $(GRAPHAPP_LIB)
+PKG_CPPFLAGS += $(XTRA_PKG_CPPFLAGS)


### PR DESCRIPTION
This will get the libraries to link on Windows from pkg-config, when available. Also it fixes linking for Rtools43 versions that didn't have pkg-config, yet.