### PR TITLE
Fix compilation when CAIRO_HAS_PDF_SURFACE is false

### DIFF
--- a/src/pdf-backend.c
+++ b/src/pdf-backend.c
@@ -139,7 +139,7 @@ Rcairo_backend *Rcairo_new_pdf_backend(Rcairo_backend *be, int conn, const char 
 #else
 Rcairo_backend_def *RcairoBackendDef_pdf = 0;
 
-Rcairo_backend *Rcairo_new_pdf_backend(Rcairo_backend *be, int conn, const char *filename, double width, double height)
+Rcairo_backend *Rcairo_new_pdf_backend(Rcairo_backend *be, int conn, const char *filename, double width, double height, SEXP aux)
 {
 	error("cairo library was compiled without PDF back-end.");
 	return NULL;


### PR DESCRIPTION
In this case the signature of the `Rcairo_new_pdf_backend` funciton definition didn't match the one in the declaration (the final `SEXP` argument was missing), causing the compilation to fail.

I found this while compiling the CRAN version 1.6.2, but this file hasn't been touched in a long time, so it probably affects older versions too.