### PR TITLE
Update configure.win, add --vanilla for runtime determination

### DIFF
--- a/configure.win
+++ b/configure.win
@@ -2,7 +2,7 @@
 
 echo "  checking Windows runtime"
 
-runtime=`"${R_HOME}/bin/Rscript" -e 'cat(R.version$crt)'`
+runtime=`"${R_HOME}/bin/Rscript" --vanilla -e 'cat(R.version$crt)'`
 echo "  found: '$runtime'"
 
 if [ x"$runtime" = xucrt ]; then


### PR DESCRIPTION
added --vanilla flag to Rscript when determining the runtime version.  
Running without --vanilla flag garbles up the output if user profile is present and loaded and causes the runtime not to be determined properly (and consequently for src/cconfig.h to not get created thus failing the compilation.